### PR TITLE
feat(distill): add /distill skill for interactive persona generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is gh-persona
+
+A `gh` CLI extension that applies **personas** to Claude Code sessions via git worktree + CLAUDE.md injection. It creates an isolated worktree, builds a composite CLAUDE.md (original + persona base + perspective + knowledge index), and drops the user into it.
+
+## Usage
+
+```bash
+gh persona investor/macro        # Activate persona in a new worktree
+gh persona list                  # List available personas
+gh persona clean [name]          # Remove worktree(s)
+```
+
+### Persona generation
+
+```bash
+/distill investor                # Interactively distill a persona from knowledge base
+/distill investor/value          # Distill with a pre-determined perspective name
+```
+
+`/distill` is a Claude Code skill (not a gh subcommand). It reads knowledge files from the knowledge DB, conducts an interactive dialogue to capture thinking style, and generates `base.md`, `perspectives/<name>.md`, and `knowledge-index.md`.
+
+The script is a standalone bash executable (`gh-persona` at project root). No build step or dependencies beyond `git` and `bash`. Optional: `fzf` for interactive selection.
+
+## Architecture
+
+### Persona structure
+
+```
+personas/<domain>/
+  base.md                    # Domain-level role, principles, thinking style
+  knowledge-index.md         # What the persona knows / doesn't know
+  perspectives/<name>.md     # Specific analytical lens within the domain
+```
+
+A persona is identified as `<domain>/<perspective>` (e.g. `investor/macro`).
+
+### CLAUDE.md composition order
+
+`build_claude_md()` concatenates in this order:
+1. Original CLAUDE.md from the target repo (if exists)
+2. `---` separator
+3. `base.md` — domain role definition
+4. `perspectives/<name>.md` — perspective-specific focus
+5. `knowledge-index.md` — knowledge boundary declaration (if exists)
+
+### Worktree lifecycle
+
+- Created at `${GH_PERSONA_WORKTREE_BASE:-/tmp/persona}-<domain>-<perspective>`
+- Branch name: `persona-<domain>-<perspective>`
+- `clean` subcommand handles removal (single or interactive bulk)
+
+## Development notes
+
+- The script uses `set -euo pipefail` — all errors are fatal
+- `SCRIPT_DIR` is resolved to the script's location, so `personas/` is always found relative to the installed extension
+- Test by running `./gh-persona list` or `./gh-persona investor/macro` from within any git repo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# gh-persona
+
+A `gh` CLI extension that applies **personas** to Claude Code sessions via git worktree + CLAUDE.md injection.
+
+## Setup
+
+### 1. Install as gh extension
+
+```bash
+gh extension install A-hosoda/gh-persona
+```
+
+Or link locally for development:
+
+```bash
+gh extension install .
+```
+
+### 2. Install skills (optional)
+
+Skills are Claude Code slash commands shipped with this repo. To use them, symlink the `skills/` directory into your Claude Code config:
+
+```bash
+# Symlink each skill into ~/.claude/skills/
+ln -s "$(pwd)/skills/distill" ~/.claude/skills/distill
+```
+
+Or link all skills at once:
+
+```bash
+for skill_dir in skills/*/; do
+  skill_name=$(basename "$skill_dir")
+  ln -sf "$(cd "$skill_dir" && pwd)" ~/.claude/skills/"$skill_name"
+done
+```
+
+Verify with `claude` — the skill should appear in the `/` command list.
+
+### 3. Prerequisites
+
+- `git` and `bash`
+- `gh` CLI
+- `claude` (Claude Code) for skills
+- Optional: `fzf` for interactive persona selection
+
+## Usage
+
+### CLI commands
+
+```bash
+gh persona investor/macro        # Activate persona in a new worktree
+gh persona list                  # List available personas
+gh persona clean [name]          # Remove worktree(s)
+```
+
+### Skills (Claude Code slash commands)
+
+```
+/distill investor                # Interactively distill a persona from knowledge base
+/distill investor/value          # Distill with a pre-determined perspective name
+```
+
+## Persona structure
+
+```
+personas/<domain>/
+  base.md                    # Domain-level role, principles, thinking style
+  knowledge-index.md         # What the persona knows / doesn't know
+  perspectives/<name>.md     # Specific analytical lens within the domain
+```
+
+A persona is identified as `<domain>/<perspective>` (e.g. `investor/macro`).
+
+## How it works
+
+1. Creates an isolated git worktree
+2. Builds a composite CLAUDE.md by concatenating:
+   - Original CLAUDE.md from the target repo
+   - `base.md` (domain role definition)
+   - `perspectives/<name>.md` (perspective-specific focus)
+   - `knowledge-index.md` (knowledge boundaries)
+3. Drops the user into the worktree with the persona applied
+
+## License
+
+MIT

--- a/skills/distill/SKILL.md
+++ b/skills/distill/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: distill
+description: >-
+  知見ベースからペルソナを対話的に蒸留する。
+  knowledge-index.md は知見ファイルから自動生成し、
+  base.md と perspectives/ は対話を通じて形成する。
+allowed-tools: Read, Glob, Grep, Write, Bash
+model: claude-sonnet-4-6
+argument-hint: "<domain> [domain/perspective]"
+context: conversation
+---
+
+# Distill - Interactive Persona Generation from Knowledge Base
+
+知見ファイル群を分析し、対話を通じてペルソナを蒸留する。
+
+## Constants
+
+- Knowledge DB: `~/Develop/mywork/knowledge-base/docs/knowledges/knowledge.db`
+- Output: `~/Develop/mywork/claude-code/gh-persona/personas/<domain>/`
+
+## Step 1: Parse arguments
+
+Parse `$ARGUMENTS` to determine domain and optional perspective.
+
+- `investor` → domain=investor, perspective=undecided (decide at Step 5)
+- `investor/value` → domain=investor, perspective=value
+
+If no arguments, ask the user for domain name via AskUserQuestion.
+
+## Step 2: Collect knowledge files
+
+### 2a: Load categories from DB
+
+```bash
+sqlite3 ~/Develop/mywork/knowledge-base/docs/knowledges/knowledge.db "SELECT name, description FROM categories;"
+```
+
+### 2b: Category selection
+
+Use AskUserQuestion with `multiSelect: true` to let the user select relevant categories.
+
+### 2c: Load entries from selected categories
+
+```bash
+sqlite3 ~/Develop/mywork/knowledge-base/docs/knowledges/knowledge.db \
+  "SELECT path, summary FROM entries WHERE category IN ('cat1','cat2');"
+```
+
+### 2d: Knowledge selection
+
+Present entries and use AskUserQuestion with `multiSelect: true` to let the user select which knowledge files to include.
+
+### 2e: Read selected files
+
+Read all selected knowledge files to understand their content.
+
+## Step 3: Analyze and cluster
+
+Analyze the selected knowledge files and present:
+
+1. **Theme clusters** — group related knowledge into themes
+2. **Key patterns** — recurring principles or approaches
+3. **Tensions** — contradictions or trade-offs between entries
+
+Present this analysis to the user. This forms the foundation for the dialogue in Step 4.
+
+## Step 4: Interactive thinking style exploration (3-5 turns)
+
+Engage in dialogue with the user to understand how they think about this domain.
+Use AskUserQuestion for structured questions, and open-ended follow-ups as needed.
+
+### Question patterns (use 3-5, adapt based on responses)
+
+1. **Core principle**: 「この知見群の中で最も重視している原則は何ですか？」
+   - Present the themes from Step 3 as options
+
+2. **Contradiction resolution**: Present a specific tension found in Step 3 and ask:
+   「この2つの知見は矛盾しているように見えます。どちらを優先しますか？その理由は？」
+
+3. **Starting point**: 「分析を始めるとき、まず何から考えますか？」
+   - Offer frameworks identified from the knowledge as options
+
+4. **Communication style**: 「分析結果を伝えるとき、どういうトーンが適切ですか？」
+   - Options: Direct/blunt, Balanced, Cautious/hedged, Data-first
+
+5. **Intentional bias**: 「意図的に持っておきたい偏り（バイアス）はありますか？」
+   - Derive options from patterns in the knowledge
+
+Adapt the questions based on previous answers. Skip questions that have already been answered implicitly.
+
+## Step 5: Determine perspective name
+
+If perspective was not specified in arguments:
+
+Use AskUserQuestion to propose 2-3 perspective names based on the dialogue so far.
+Each name should reflect the analytical lens that emerged from the conversation.
+
+## Step 6: Generate drafts
+
+Generate three draft files based on all information gathered:
+
+### 6a: `base.md`
+
+Follow the format of existing `personas/investor/base.md`:
+
+```markdown
+# Persona: <Domain>
+
+## Role
+
+(Domain-level role description)
+
+## Core Principles
+
+(Derived from Step 4 dialogue — what the user prioritizes)
+
+## Thinking Style
+
+(Derived from Step 4 dialogue — how the user approaches analysis)
+- 深い分析や判断が必要な場面では `/oracle` を使って知見ベースを参照し、蓄積された知見に基づいて思考する
+
+## Communication
+
+(Derived from Step 4 dialogue — tone and style)
+```
+
+### 6b: `perspectives/<name>.md`
+
+Follow the format of existing `personas/investor/perspectives/macro.md`:
+
+```markdown
+# Perspective: <Name>
+
+## Focus Areas
+
+(Derived from selected knowledge themes)
+
+## Analytical Framework
+
+(Derived from Step 4 dialogue — how analysis is structured)
+
+## Biases (Intentional)
+
+(Derived from Step 4 dialogue — deliberate analytical biases)
+```
+
+### 6c: `knowledge-index.md`
+
+Auto-generated from the selected knowledge files:
+
+```markdown
+# Knowledge Index: <Domain>
+
+## What I Know
+
+(One-line summary per selected knowledge file, organized by theme)
+
+## What I Don't Know
+
+(Gaps identified from the knowledge analysis — areas not covered)
+```
+
+### Present drafts
+
+Display all three drafts to the user for review.
+
+## Step 7: Review and refine
+
+Enter a review loop:
+- Ask the user if they want to modify any of the drafts
+- Apply requested changes
+- Repeat until the user is satisfied
+
+## Step 8: Write files
+
+Write the finalized files:
+
+```
+~/Develop/mywork/claude-code/gh-persona/personas/<domain>/base.md
+~/Develop/mywork/claude-code/gh-persona/personas/<domain>/perspectives/<perspective>.md
+~/Develop/mywork/claude-code/gh-persona/personas/<domain>/knowledge-index.md
+```
+
+Create directories if they don't exist:
+```bash
+mkdir -p ~/Develop/mywork/claude-code/gh-persona/personas/<domain>/perspectives
+```
+
+If `base.md` or `knowledge-index.md` already exists, ask the user before overwriting.
+
+## Step 9: Report completion
+
+```
+**`/distill` 完了**
+
+生成ファイル:
+- `personas/<domain>/base.md`
+- `personas/<domain>/perspectives/<perspective>.md`
+- `personas/<domain>/knowledge-index.md`
+
+ペルソナを適用するには:
+  gh persona <domain>/<perspective>
+```
+
+## Rules
+
+- Never write files without user confirmation of the drafts (Step 7)
+- Always include `/oracle` usage instruction in Thinking Style section of base.md
+- Follow existing persona file formats exactly (see `personas/investor/` for reference)
+- Knowledge-index.md is auto-generated; base.md and perspectives/ are dialogue-driven
+- Minimum 3 turns of dialogue in Step 4 before generating drafts
+- If the domain already has a base.md, read it first and ask whether to update or replace


### PR DESCRIPTION
Add a Claude Code skill that distills personas from the knowledge base through interactive dialogue. The skill generates base.md, perspectives/, and knowledge-index.md files following existing persona format.

Also adds README.md with setup instructions including skill symlink setup, and updates CLAUDE.md with /distill usage documentation.

Closes #3